### PR TITLE
3 project paused as the project page wasn't visited in 4 days

### DIFF
--- a/albumgenerator.py
+++ b/albumgenerator.py
@@ -8,6 +8,10 @@ def get_project_api_url(username):
     return f"https://1001albumsgenerator.com/api/v1/projects/{clean_username(username)}"
 
 
+def get_project_main_url(username):
+    return f"https://1001albumsgenerator.com/{clean_username(username)}"
+
+
 def clean_username(username):
     return username.lower().strip().replace(" ", "-")
 
@@ -18,6 +22,14 @@ def get_api_json(url):
         return r.json()
     else:
         raise Exception("API request failed")
+
+
+def get_project_page(url):
+    r = requests.get(url)
+    if r.status_code == 200:
+        return r.text
+    else:
+        raise Exception("HTTP request failed")
 
 
 def generate_spotify_app_url(spotify_id: str) -> str:

--- a/albumgenerator.py
+++ b/albumgenerator.py
@@ -4,7 +4,7 @@ from typing import Dict
 import requests
 
 
-def get_project_url(username):
+def get_project_api_url(username):
     return f"https://1001albumsgenerator.com/api/v1/projects/{clean_username(username)}"
 
 

--- a/main.py
+++ b/main.py
@@ -71,7 +71,6 @@ def main():
         notification_job(args.config)
         return
 
-    # Grab the album generator API content to confirm it's a valid project
     url = albumgenerator.get_project_api_url(album_config.project_name)
     api_data = albumgenerator.get_api_json(url)
     album_data = albumgenerator.extract_album_data(api_data)

--- a/main.py
+++ b/main.py
@@ -46,6 +46,9 @@ def notification_job(config_path: str) -> None:
     album_config, schedule_config, ntfy_config = load_config(config_path)
     log_configuration(album_config, schedule_config, ntfy_config)
 
+    # Visit the project page to ensure that the project doesn't get marked inactive
+    albumgenerator.get_project_page(albumgenerator.get_project_main_url(album_config.project_name))
+
     url = albumgenerator.get_project_api_url(album_config.project_name)
     api_data = albumgenerator.get_api_json(url)
     album_data = albumgenerator.extract_album_data(api_data)

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def notification_job(config_path: str) -> None:
     album_config, schedule_config, ntfy_config = load_config(config_path)
     log_configuration(album_config, schedule_config, ntfy_config)
 
-    url = albumgenerator.get_project_url(album_config.project_name)
+    url = albumgenerator.get_project_api_url(album_config.project_name)
     api_data = albumgenerator.get_api_json(url)
     album_data = albumgenerator.extract_album_data(api_data)
     message, headers = prepare_message(album_data)
@@ -72,7 +72,7 @@ def main():
         return
 
     # Grab the album generator API content to confirm it's a valid project
-    url = albumgenerator.get_project_url(album_config.project_name)
+    url = albumgenerator.get_project_api_url(album_config.project_name)
     api_data = albumgenerator.get_api_json(url)
     album_data = albumgenerator.extract_album_data(api_data)
     message, headers = prepare_message(album_data)


### PR DESCRIPTION
Add some code which will pull down the main project page before accessing the API to ensure that the project doesn't get marked inactive