### PR TITLE
Fix unpause logic

### DIFF
--- a/albumgenerator.py
+++ b/albumgenerator.py
@@ -12,6 +12,10 @@ def get_project_main_url(username):
     return f"https://1001albumsgenerator.com/{clean_username(username)}"
 
 
+def get_project_unpause_url(username):
+    return f"https://1001albumsgenerator.com/api/project/{clean_username(username)}/paused"
+
+
 def clean_username(username):
     return username.lower().strip().replace(" ", "-")
 
@@ -29,6 +33,13 @@ def get_project_page(url):
     if r.status_code == 200:
         return r.text
     else:
+        raise Exception("HTTP request failed")
+
+
+def unpause_project(username):
+    url = get_project_unpause_url(username)
+    r = requests.post(url, json={"paused": False})
+    if r.status_code != 200:
         raise Exception("HTTP request failed")
 
 

--- a/main.py
+++ b/main.py
@@ -46,8 +46,9 @@ def notification_job(config_path: str) -> None:
     album_config, schedule_config, ntfy_config = load_config(config_path)
     log_configuration(album_config, schedule_config, ntfy_config)
 
-    # Visit the project page to ensure that the project doesn't get marked inactive
-    albumgenerator.get_project_page(albumgenerator.get_project_main_url(album_config.project_name))
+    # Unpause the project - the project will auto-pause after four days
+    # if you don't interact with the page
+    albumgenerator.unpause_project(album_config.project_name)
 
     url = albumgenerator.get_project_api_url(album_config.project_name)
     api_data = albumgenerator.get_api_json(url)


### PR DESCRIPTION
Looks like the last change I made didn't actually work. There is an API which I uncovered by watching the console which allows the project to be directly unpaused.
Thinking about it again, I've got some concern that it will still not entirely work as the project will presumably be paused at the same time that the new album is generated meaning that we may miss a day! Not sure how to resolve this yet if this is indeed an issue.